### PR TITLE
Refresh setup automation for current dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,11 @@ Install ffmpeg on path
 git clone https://github.com/tltrogl/redo.git
 cd redo
 
-# Run setup script
+# Run setup script (add -Force to auto-confirm prompts in CI)
 .\setup.ps1
+# .\setup.ps1 -Force            # auto-confirm prompts
+# .\setup.ps1 -RuntimeOnly      # skip dev extras (runtime deps only)
+# .\setup.ps1 -SkipDiagnostics  # omit diagnostics command
 ```
 
 **Option 2: Manual Setup**
@@ -196,8 +199,9 @@ py -3.11 -m venv .venv
 # 3. Install dependencies
 python -m pip install -U pip wheel setuptools
 pip install -r requirements.txt
-# Optional (development): keep editable install for local code changes
-pip install -e .
+# Optional (development): install editable package with tooling extras
+pip install -e ".[dev]"
+# If extras fail (for example on minimal CI images), fall back to: pip install -e .
 
 # 5. Verify installation
 python -m diaremot.cli diagnostics
@@ -215,7 +219,16 @@ cd redo
 # Make setup script executable and run
 chmod +x setup.sh
 ./setup.sh
+# ./setup.sh --yes              # auto-confirm prompts
+# ./setup.sh --runtime-only     # skip dev extras
+# ./setup.sh --skip-diagnostics # omit diagnostics command
 ```
+
+Both setup scripts detect when no interactive TTY is available and fall back to the safe default (for example, aborting instead of
+continuing without FFmpeg or leaving an existing virtual environment intact). Pass `--yes` on Linux/macOS or `-Force` on Windows
+to auto-accept prompts in automation; the scripts emit a warning when proceeding automatically. Development dependencies are
+installed by default—use `--runtime-only` / `-RuntimeOnly` to limit the install to runtime packages, or `--skip-diagnostics`
+/ `-SkipDiagnostics` to bypass the optional health check when operating in constrained environments.
 
 **Option 2: Manual Setup**
 install ffmpeg to path
@@ -231,8 +244,9 @@ source .venv/bin/activate
 # 3. Install dependencies
 pip install -U pip wheel setuptools
 pip install -r requirements.txt
-# Optional (development): keep editable install for local code changes
-pip install -e .
+# Optional (development): install editable package with tooling extras
+pip install -e ".[dev]"
+# If extras fail (for example on minimal CI images), fall back to: pip install -e .
 
 # 4. Verify installation
 python -m diaremot.cli diagnostics

--- a/setup.sh
+++ b/setup.sh
@@ -1,170 +1,282 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 # DiaRemot Setup Script for Linux/macOS
-# This script sets up the Python environment and installs all dependencies
+# This script provisions a virtual environment, installs runtime (and optionally
+# development) dependencies, and runs basic diagnostics.
 
 PYTHON_VERSION="3.11"
+ALT_PYTHON_VERSION="3.12"
 VENV_DIR=".venv"
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-echo "========================================"
-echo "DiaRemot Setup Script"
-echo "========================================"
-echo ""
-
-# Color codes for output
+# Colour codes for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+BLUE='\033[1;34m'
+NC='\033[0m' # No Colour
 
-# Check for Python
-echo "Checking for Python ${PYTHON_VERSION}..."
-if command -v python${PYTHON_VERSION} &> /dev/null; then
+ASSUME_YES=false
+RUNTIME_ONLY=false
+RUN_DIAGNOSTICS=true
+
+usage() {
+    cat <<EOF
+Usage: $0 [options]
+
+Options:
+  --yes, -y             Auto-confirm prompts (useful in CI)
+  --runtime-only        Skip developer extras when installing diaremot
+  --skip-diagnostics    Do not run python -m diaremot.cli diagnostics
+  --help, -h            Show this message and exit
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --yes|-y)
+            ASSUME_YES=true
+            shift
+            ;;
+        --runtime-only)
+            RUNTIME_ONLY=true
+            shift
+            ;;
+        --skip-diagnostics)
+            RUN_DIAGNOSTICS=false
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Unknown option: $1${NC}" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [ -t 0 ]; then
+    HAS_TTY=true
+else
+    HAS_TTY=false
+fi
+
+if [ "$ASSUME_YES" = true ]; then
+    echo -e "${YELLOW}--yes supplied; all prompts will be auto-confirmed.${NC}"
+elif [ "$HAS_TTY" != true ]; then
+    echo -e "${YELLOW}No interactive terminal detected; default responses will be used for prompts.${NC}"
+fi
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}DiaRemot Setup Script${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+
+# Helper to confirm actions with optional defaults
+confirm() {
+    local message="$1"
+    local default="${2:-N}"
+    local default_upper="${default^^}"
+    local prompt_suffix
+
+    if [[ "$default_upper" == "Y" ]]; then
+        prompt_suffix="(Y/n)"
+    else
+        prompt_suffix="(y/N)"
+    fi
+
+    if [ "$ASSUME_YES" = true ]; then
+        echo -e "${YELLOW}${message} ${prompt_suffix} -- proceeding automatically due to --yes.${NC}"
+        return 0
+    fi
+
+    if [ "$HAS_TTY" != true ]; then
+        echo -e "${YELLOW}${message} ${prompt_suffix} (no TTY detected; defaulting to ${default_upper}).${NC}"
+        [[ "$default_upper" == "Y" ]]
+        return $?
+    fi
+
+    local reply
+    read -r -p "${message} ${prompt_suffix} " reply
+    if [ -z "$reply" ]; then
+        reply="$default_upper"
+    else
+        reply="${reply^^}"
+    fi
+
+    [[ "$reply" == "Y" ]]
+}
+
+info() {
+    echo -e "${BLUE}$1${NC}"
+}
+
+success() {
+    echo -e "${GREEN}$1${NC}"
+}
+
+warn() {
+    echo -e "${YELLOW}$1${NC}"
+}
+
+error() {
+    echo -e "${RED}$1${NC}" >&2
+}
+
+info "Checking for Python ${PYTHON_VERSION}/${ALT_PYTHON_VERSION}..."
+PYTHON_CMD=""
+if command -v python${PYTHON_VERSION} >/dev/null 2>&1; then
     PYTHON_CMD="python${PYTHON_VERSION}"
-elif command -v python3.11 &> /dev/null; then
-    PYTHON_CMD="python3.11"
-elif command -v python3 &> /dev/null; then
+elif command -v python${ALT_PYTHON_VERSION} >/dev/null 2>&1; then
+    PYTHON_CMD="python${ALT_PYTHON_VERSION}"
+elif command -v python3 >/dev/null 2>&1; then
     PYTHON_CMD="python3"
-    CURRENT_VERSION=$($PYTHON_CMD --version 2>&1 | cut -d' ' -f2 | cut -d'.' -f1,2)
-    if [[ "$CURRENT_VERSION" != "3.11" ]] && [[ "$CURRENT_VERSION" != "3.12" ]]; then
-        echo -e "${RED}Error: Python 3.11 or 3.12 required, found $CURRENT_VERSION${NC}"
+    CURRENT_VERSION=$($PYTHON_CMD --version 2>&1 | awk '{print $2}')
+    MAJOR_MINOR=${CURRENT_VERSION%.*}
+    if [[ "$MAJOR_MINOR" != "3.11" && "$MAJOR_MINOR" != "3.12" ]]; then
+        error "Error: Python 3.11 or 3.12 required, found ${CURRENT_VERSION}"
         exit 1
     fi
 else
-    echo -e "${RED}Error: Python ${PYTHON_VERSION} not found!${NC}"
+    error "Error: Python ${PYTHON_VERSION} not found!"
     echo "Please install Python 3.11 or 3.12 and try again."
     exit 1
 fi
-
-PYTHON_VERSION_FULL=$($PYTHON_CMD --version 2>&1 | cut -d' ' -f2)
-echo -e "${GREEN}Found: Python ${PYTHON_VERSION_FULL}${NC}"
+PYTHON_VERSION_FULL=$($PYTHON_CMD --version 2>&1 | awk '{print $2}')
+success "Found: Python ${PYTHON_VERSION_FULL}"
 echo ""
 
-# Check for FFmpeg
-echo "Checking for FFmpeg..."
-if command -v ffmpeg &> /dev/null; then
-    FFMPEG_VERSION=$(ffmpeg -version 2>&1 | head -n1 | cut -d' ' -f3)
-    echo -e "${GREEN}Found: FFmpeg ${FFMPEG_VERSION}${NC}"
+info "Checking for FFmpeg..."
+if command -v ffmpeg >/dev/null 2>&1; then
+    FFMPEG_VERSION=$(ffmpeg -version 2>&1 | head -n1 | awk '{print $3}')
+    success "Found: FFmpeg ${FFMPEG_VERSION}"
 else
-    echo -e "${YELLOW}Warning: FFmpeg not found!${NC}"
+    warn "FFmpeg not found!"
     echo "FFmpeg is required for audio processing. Install with:"
-    echo "  Ubuntu/Debian: sudo apt-get install ffmpeg"
+    echo "  Ubuntu/Debian: sudo apt-get install -y ffmpeg"
     echo "  macOS:         brew install ffmpeg"
     echo ""
-    read -p "Continue anyway? (y/N) " -n 1 -r
-    echo
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    if ! confirm "Continue anyway?" "N"; then
         exit 1
     fi
 fi
 echo ""
 
-# Create virtual environment
 if [ -d "$VENV_DIR" ]; then
-    echo -e "${YELLOW}Virtual environment already exists at ${VENV_DIR}${NC}"
-    read -p "Remove and recreate? (y/N) " -n 1 -r
-    echo
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-        echo "Removing existing virtual environment..."
+    warn "Virtual environment already exists at ${VENV_DIR}"
+    if confirm "Remove and recreate?" "N"; then
+        info "Removing existing virtual environment..."
         rm -rf "$VENV_DIR"
     else
-        echo "Using existing virtual environment..."
+        info "Using existing virtual environment..."
     fi
 fi
 
 if [ ! -d "$VENV_DIR" ]; then
-    echo "Creating virtual environment..."
+    info "Creating virtual environment..."
     $PYTHON_CMD -m venv "$VENV_DIR"
-    echo -e "${GREEN}Virtual environment created${NC}"
+    success "Virtual environment created"
 fi
 echo ""
 
-# Activate virtual environment
-echo "Activating virtual environment..."
+info "Activating virtual environment..."
+# shellcheck source=/dev/null
 source "$VENV_DIR/bin/activate"
-echo -e "${GREEN}Virtual environment activated${NC}"
+success "Virtual environment activated"
 echo ""
 
-# Upgrade pip, wheel, setuptools
-echo "Upgrading pip, wheel, and setuptools..."
+info "Upgrading pip, wheel, and setuptools..."
 python -m pip install --upgrade pip wheel setuptools
-echo -e "${GREEN}Package managers upgraded${NC}"
+success "Package managers upgraded"
 echo ""
 
-# Install project dependencies
-echo "Installing project dependencies..."
-if [ -f "requirements.txt" ]; then
-    pip install -r requirements.txt
-    echo -e "${GREEN}Dependencies installed${NC}"
+info "Installing project dependencies from requirements.txt..."
+if [ -f "$PROJECT_ROOT/requirements.txt" ]; then
+    python -m pip install -r "$PROJECT_ROOT/requirements.txt"
+    success "Runtime dependencies installed"
 else
-    echo -e "${RED}Error: requirements.txt not found!${NC}"
+    error "Error: requirements.txt not found at $PROJECT_ROOT"
     exit 1
 fi
 echo ""
 
-# Install PyTorch CPU (if not already installed)
-echo "Checking PyTorch installation..."
-if python -c "import torch" 2>/dev/null; then
-    echo -e "${GREEN}PyTorch already installed${NC}"
-else
-    echo "Installing PyTorch CPU..."
-    pip install --index-url https://download.pytorch.org/whl/cpu torch
-    echo -e "${GREEN}PyTorch CPU installed${NC}"
-fi
-echo ""
-
-# Install package in editable mode
-echo "Installing diaremot package in editable mode..."
-pip install -e .
-echo -e "${GREEN}Package installed${NC}"
-echo ""
-
-# Create necessary directories
-echo "Creating necessary directories..."
-mkdir -p .cache/hf .cache/torch .cache/transformers
-mkdir -p checkpoints outputs logs data
-echo -e "${GREEN}Directories created${NC}"
-echo ""
-
-# Check model directory
-echo "Checking model directory..."
-if [ -z "$DIAREMOT_MODEL_DIR" ]; then
-    if [ -d "/srv/models" ]; then
-        MODEL_DIR="/srv/models"
-    elif [ -d "$HOME/models" ]; then
-        MODEL_DIR="$HOME/models"
-    elif [ -d "models" ]; then
-        MODEL_DIR="models"
-    else
-        echo -e "${YELLOW}Warning: No model directory found${NC}"
-        echo "Set DIAREMOT_MODEL_DIR environment variable or create:"
-        echo "  /srv/models (recommended)"
-        echo "  ~/models"
-        echo "  ./models"
-        MODEL_DIR=""
+install_editable() {
+    if [ "$RUNTIME_ONLY" = true ]; then
+        info "Installing diaremot in editable mode (runtime dependencies only)..."
+        python -m pip install -e "$PROJECT_ROOT"
+        return
     fi
-else
+
+    info "Installing diaremot with development extras..."
+    if python -m pip install -e "$PROJECT_ROOT[dev]"; then
+        return
+    fi
+
+    warn "Editable install with dev extras failed; falling back to runtime-only editable install."
+    python -m pip install -e "$PROJECT_ROOT"
+}
+
+install_editable
+success "Package installation complete"
+echo ""
+
+info "Creating cache and output directories..."
+mkdir -p .cache/hf .cache/torch .cache/transformers .cache/hub
+mkdir -p checkpoints outputs logs data
+success "Directories ensured"
+echo ""
+
+info "Checking model directory..."
+MODEL_DIR=""
+if [ -n "${DIAREMOT_MODEL_DIR:-}" ]; then
     MODEL_DIR="$DIAREMOT_MODEL_DIR"
+elif [ -d "/srv/models" ]; then
+    MODEL_DIR="/srv/models"
+elif [ -d "$HOME/models" ]; then
+    MODEL_DIR="$HOME/models"
+elif [ -d "models" ]; then
+    MODEL_DIR="models"
 fi
 
 if [ -n "$MODEL_DIR" ]; then
-    echo -e "${GREEN}Model directory: ${MODEL_DIR}${NC}"
+    success "Model directory: ${MODEL_DIR}"
 else
-    echo -e "${YELLOW}No model directory configured${NC}"
+    warn "No model directory configured"
+    echo "Set DIAREMOT_MODEL_DIR or create one of the following:"
+    echo "  /srv/models (recommended for shared hosts)"
+    echo "  ~/models"
+    echo "  ./models"
 fi
 echo ""
 
-# Run diagnostics
-echo "Running diagnostics..."
-python -m diaremot.cli diagnostics
-echo ""
+run_diagnostics() {
+    if [ "$RUN_DIAGNOSTICS" != true ]; then
+        info "Skipping diagnostics (--skip-diagnostics provided)."
+        return
+    fi
 
-# Setup complete
-echo "========================================"
-echo -e "${GREEN}Setup Complete!${NC}"
-echo "========================================"
+    info "Running diagnostics (python -m diaremot.cli diagnostics)..."
+    set +e
+    python -m diaremot.cli diagnostics
+    status=$?
+    set -e
+    if [ $status -ne 0 ]; then
+        warn "Diagnostics exited with status $status. Review the output above for details."
+    else
+        success "Diagnostics completed successfully"
+    fi
+    echo ""
+}
+
+run_diagnostics
+
+echo -e "${BLUE}========================================${NC}"
+success "Setup Complete!"
+echo -e "${BLUE}========================================${NC}"
 echo ""
 echo "To activate the environment in future sessions:"
 echo "  source ${VENV_DIR}/bin/activate"


### PR DESCRIPTION
## Summary
- rewrite the Linux/macOS setup script to default to dev extras, add runtime-only/skip-diagnostics flags, and drop the legacy torch installer
- align the Windows setup script with the same options and non-interactive handling while avoiding redundant torch installs
- document the new automation flags and editable install guidance in the quick start instructions

## Testing
- ./setup.sh --yes *(diagnostics currently raises ModuleNotFoundError: No module named 'diaremot.pipeline.io')*


------
https://chatgpt.com/codex/tasks/task_e_6900750afe58832eaf32bdb08c412f45