### PR TITLE
Add async transcription support

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,13 @@ export TOKENIZERS_PARALLELISM=false
 
 **IMPORTANT:** `local_first` controls search PRIORITY only. Downloaded models (especially faster-whisper) ALWAYS cache to `$HF_HOME/.cache/` - there is no way to disable caching. This is CTranslate2/HuggingFace default behavior.
 
+### ASR concurrency
+
+- Set `enable_async_transcription: true` in your pipeline configuration to run the non-blocking Faster-Whisper scheduler. The
+  ASR stage awaits all batches concurrently and emits segments in deterministic time order.
+- Use `--async-asr` when invoking `diaremot run` or `diaremot core` to enable the same behaviour from the CLI.
+- Leaving the flag disabled preserves the synchronous execution path for environments where lightweight scheduling is preferred.
+
 ### Model Search Paths
 
 DiaRemot uses a priority-based model discovery system. For each model, the system searches these locations in order:

--- a/src/diaremot/cli.py
+++ b/src/diaremot/cli.py
@@ -110,6 +110,12 @@ def core(
     vad_min_silence_sec: float | None = typer.Option(0.25, help="Minimum silence duration (s)"),
     vad_speech_pad_sec: float | None = typer.Option(0.20, help="Pad around detected speech (s)"),
     asr_cpu_threads: int | None = typer.Option(None, help="CPU threads for ASR backend"),
+    async_transcription: bool = typer.Option(
+        False,
+        "--async-asr",
+        help="Enable asynchronous transcription engine",
+        is_flag=True,
+    ),
 ):
     _apply_model_root(model_root)
     target_out = outdir or _default_outdir_for_input(input)
@@ -128,6 +134,7 @@ def core(
             asr_cpu_threads,
         )
     )
+    overrides["enable_async_transcription"] = bool(async_transcription)
     manifest = core_run_pipeline(str(input), str(target_out), config=overrides)
     typer.echo(_make_json_safe(manifest))
 
@@ -498,6 +505,12 @@ def run(
     asr_backend: str = typer.Option("faster", help="ASR backend", show_default=True),
     asr_compute_type: str = typer.Option("int8", help="CT2 compute type for faster-whisper."),
     asr_cpu_threads: int = typer.Option(1, help="CPU threads for ASR backend."),
+    async_asr: bool = typer.Option(
+        False,
+        "--async-asr",
+        help="Enable asynchronous transcription engine.",
+        is_flag=True,
+    ),
     language: str | None = typer.Option(None, help="Override ASR language"),
     language_mode: str = typer.Option("auto", help="Language detection mode"),
     ignore_tx_cache: bool = typer.Option(
@@ -646,6 +659,7 @@ def run(
         "language": language,
         "language_mode": language_mode,
         "ignore_tx_cache": ignore_tx_cache,
+        "enable_async_transcription": bool(async_asr),
         "quiet": quiet,
         "disable_affect": disable_affect,
         "affect_backend": affect_backend,

--- a/src/diaremot/pipeline/config.py
+++ b/src/diaremot/pipeline/config.py
@@ -62,6 +62,7 @@ class PipelineConfig:
     language: str | None = None
     language_mode: str = "auto"
     ignore_tx_cache: bool = False
+    enable_async_transcription: bool = False
     quiet: bool = False
     disable_affect: bool = False
     affect_backend: str = "onnx"
@@ -180,6 +181,7 @@ class PipelineConfig:
         else:
             raise ValueError("enable_sed must be a boolean value")
         self.enable_sed = bool(self.enable_sed)
+        self.enable_async_transcription = bool(self.enable_async_transcription)
         _ensure_numeric_range("vad_threshold", self.vad_threshold, ge=0.0, le=1.0)
         _ensure_numeric_range("temperature", self.temperature, ge=0.0, le=1.0)
         _ensure_numeric_range("no_speech_threshold", self.no_speech_threshold, ge=0.0, le=1.0)

--- a/src/diaremot/pipeline/core/component_factory.py
+++ b/src/diaremot/pipeline/core/component_factory.py
@@ -140,6 +140,7 @@ class ComponentFactoryMixin:
                 "local_first": cfg.get("local_first", True),
                 "segment_timeout_sec": cfg.get("segment_timeout_sec", 300.0),
                 "batch_timeout_sec": cfg.get("batch_timeout_sec", 1200.0),
+                "enable_async": bool(cfg.get("enable_async_transcription", False)),
             }
 
             os.environ["CUDA_VISIBLE_DEVICES"] = ""

--- a/tests/pipeline/test_asr_stage.py
+++ b/tests/pipeline/test_asr_stage.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+
+from diaremot.pipeline.stages import asr
+from diaremot.pipeline.stages.base import PipelineState
+
+
+class _GuardStub:
+    def __init__(self) -> None:
+        self.progress_calls: list[str] = []
+        self.done_calls: list[dict[str, int]] = []
+
+    def progress(self, message: str) -> None:
+        self.progress_calls.append(message)
+
+    def done(self, **kwargs: int) -> None:
+        self.done_calls.append(kwargs)
+
+
+class _CheckpointStub:
+    def __init__(self) -> None:
+        self.last_args: tuple[str, object, list[dict[str, object]], float] | None = None
+
+    def create_checkpoint(self, input_audio_path, stage, payload, progress) -> None:  # noqa: ANN001
+        self.last_args = (input_audio_path, stage, payload, progress)
+
+
+class _CoreLogStub:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, str, dict[str, str]]] = []
+
+    def stage(self, name: str, level: str, *, message: str) -> None:
+        self.messages.append((name, level, {"message": message}))
+
+
+class _AsyncTxStub:
+    def __init__(self) -> None:
+        self.async_calls = 0
+        self.sync_calls = 0
+
+    async def transcribe_segments_async(self, audio, sr, diar_segments):  # noqa: ANN001
+        self.async_calls += 1
+        await asyncio.sleep(0)
+        reversed_segments = list(reversed(diar_segments))
+        return [
+            SimpleNamespace(
+                start_time=seg["start_time"],
+                end_time=seg["end_time"],
+                text=f"seg-{idx}",
+                speaker_id=seg["speaker_id"],
+                speaker_name=seg["speaker_name"],
+                asr_logprob_avg=None,
+                snr_db=None,
+            )
+            for idx, seg in enumerate(reversed_segments)
+        ]
+
+    def transcribe_segments(self, *args, **kwargs):  # noqa: ANN001, D401 - guard misuse
+        self.sync_calls += 1
+        raise AssertionError("synchronous path should not be used when async enabled")
+
+
+class _SyncTxStub:
+    def __init__(self) -> None:
+        self.sync_calls = 0
+
+    def transcribe_segments(self, audio, sr, diar_segments):  # noqa: ANN001
+        self.sync_calls += 1
+        return [
+            SimpleNamespace(
+                start_time=seg["start_time"],
+                end_time=seg["end_time"],
+                text=f"seg-{idx}",
+                speaker_id=seg["speaker_id"],
+                speaker_name=seg["speaker_name"],
+                asr_logprob_avg=None,
+                snr_db=None,
+            )
+            for idx, seg in enumerate(diar_segments)
+        ]
+
+
+class _PipelineStub:
+    def __init__(self, tx, enable_async: bool) -> None:  # noqa: ANN001
+        self.tx = tx
+        self.pipeline_config = SimpleNamespace(
+            enable_async_transcription=enable_async
+        )
+        self.corelog = _CoreLogStub()
+        self.checkpoints = _CheckpointStub()
+        self.cache_version = "test"
+
+
+def _build_state(tmp_path: Path) -> PipelineState:
+    state = PipelineState(input_audio_path="input.wav", out_dir=tmp_path)
+    state.y = np.zeros(3200, dtype=np.float32)
+    state.sr = 16000
+    state.turns = [
+        {"start_time": 0.0, "end_time": 1.0, "speaker": "A", "speaker_name": "Alpha"},
+        {"start_time": 1.5, "end_time": 2.5, "speaker": "B", "speaker_name": "Beta"},
+    ]
+    state.cache_dir = tmp_path
+    state.audio_sha16 = "abc123"
+    state.pp_sig = {"pp": "sig"}
+    return state
+
+
+def test_asr_stage_async_orders_results(tmp_path: Path) -> None:
+    pipeline = _PipelineStub(_AsyncTxStub(), enable_async=True)
+    state = _build_state(tmp_path)
+    guard = _GuardStub()
+
+    asr.run(pipeline, state, guard)
+
+    assert pipeline.tx.async_calls == 1
+    assert pipeline.tx.sync_calls == 0
+
+    starts = [segment.start_time for segment in state.tx_out]
+    assert starts == sorted(starts)
+    assert [entry["start"] for entry in state.norm_tx] == sorted(starts)
+
+    assert guard.progress_calls[-1].endswith("(async)")
+    assert guard.done_calls[-1]["segments"] == len(state.turns)
+
+    checkpoint = pipeline.checkpoints.last_args
+    assert checkpoint is not None
+    _, _, payload, progress = checkpoint
+    assert progress == 60.0
+    assert [row["start"] for row in payload] == sorted(starts)
+
+
+def test_asr_stage_sync_fallback(tmp_path: Path) -> None:
+    pipeline = _PipelineStub(_SyncTxStub(), enable_async=False)
+    state = _build_state(tmp_path)
+    guard = _GuardStub()
+
+    asr.run(pipeline, state, guard)
+
+    assert pipeline.tx.sync_calls == 1
+    assert all("(async)" not in call for call in guard.progress_calls)
+    assert [segment.start_time for segment in state.tx_out] == [0.0, 1.5]


### PR DESCRIPTION
## Summary
- add an `enable_async_transcription` flag to the pipeline configuration, CLI, and factory wiring so the async Faster-Whisper engine can be toggled
- extend the transcriber façade with an async entry point and update the ASR stage to await async jobs while preserving ordering and checkpoint semantics
- document the new concurrency option and add regression coverage for async and synchronous paths

## Testing
- pytest tests/pipeline/test_asr_stage.py


------
https://chatgpt.com/codex/tasks/task_e_690875c4e7dc832e92fbb518385cb762